### PR TITLE
Fix broken CSS and HTML typos in work_jpmc and work_repay_2

### DIFF
--- a/work_jpmc.html
+++ b/work_jpmc.html
@@ -4,7 +4,7 @@
 	<title>Work: JP Morgan Chase</title>
 	<!-- css files -->
 	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css">
-	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.31.0.4css/bulma.min.css">
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css">
 	<link rel="stylesheet" type="text/css" href="assets/css/styles.css">
 	<link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700" rel="stylesheet">
 
@@ -17,11 +17,11 @@
 		<!-- Navbar -->
 		<nav class="navbar is-transparent">
 		  <div class="navbar-brand">
-button class="button navbar-burger" data-target="navMenu">
+		    <button class="button navbar-burger" data-target="navMenu">
 		      <span></span>
 		      <span></span>
 		      <span></span>
-    </button>
+		    </button>
 		  </div>
 
 		  <div class="navbar-menu" id="navMenu">
@@ -53,11 +53,11 @@ button class="button navbar-burger" data-target="navMenu">
 			            Nequi Neobank
 			          </a>
 								<hr class="navbar-divider">
-			          <a class="navbar-item" href="work_rappi.html" target:"_blank">
+			          <a class="navbar-item" href="work_rappi.html" target="_blank">
 			            Rappi
 			          </a>
 								<hr class="navbar-divider">
-								<a class="navbar-item" href="work_endava.html" target:"_blank">
+								<a class="navbar-item" href="work_endava.html" target="_blank">
 			            Endava Ramp-Up Journal
 			          </a>
 								<hr class="navbar-divider">

--- a/work_repay_2.html
+++ b/work_repay_2.html
@@ -4,7 +4,7 @@
 	<title>Work: repay.com</title>
 	<!-- css files -->
 	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css">
-	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.31.0.4css/bulma.min.css">
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css">
 	<link rel="stylesheet" type="text/css" href="assets/css/styles.css">
 	<link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700" rel="stylesheet">
 
@@ -17,11 +17,11 @@
 		<!-- Navbar -->
 		<nav class="navbar is-transparent">
 		  <div class="navbar-brand">
-button navbar-burger" data-target="navMenu">
+		    <button class="button navbar-burger" data-target="navMenu">
 		      <span></span>
 		      <span></span>
 		      <span></span>
-    </button>
+		    </button>
 		  </div>
 
 		  <div class="navbar-menu" id="navMenu">
@@ -53,11 +53,11 @@ button navbar-burger" data-target="navMenu">
 			            Nequi Neobank
 			          </a>
 								<hr class="navbar-divider">
-			          <a class="navbar-item" href="work_rappi.html" target:"_blank">
+			          <a class="navbar-item" href="work_rappi.html" target="_blank">
 			            Rappi
 			          </a>
 								<hr class="navbar-divider">
-								<a class="navbar-item" href="work_endava.html" target:"_blank">
+								<a class="navbar-item" href="work_endava.html" target="_blank">
 			            Endava Ramp-Up Journal
 			          </a>
 								<hr class="navbar-divider">


### PR DESCRIPTION
## Problem
Both `work_jpmc.html` and `work_repay_2.html` had CSS completely broken due to three bugs introduced during the Bulma v1.0.4 upgrade.

## Bugs fixed

### 1. Corrupted Bulma CDN URL (primary cause — no styles loading at all)
```diff
- <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.31.0.4css/bulma.min.css">
+ <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css">
```
The old `@0.9.3` version string got merged with the new `@1.0.4` path, producing a 404 — no Bulma loaded at all.

### 2. Missing `<` on navbar burger `<button>`
```diff
- button class="button navbar-burger" data-target="navMenu">
+ <button class="button navbar-burger" data-target="navMenu">
```

### 3. `target:` colon typo on two navbar links
```diff
- <a class="navbar-item" href="work_rappi.html" target:"_blank">
+ <a class="navbar-item" href="work_rappi.html" target="_blank">
- <a class="navbar-item" href="work_endava.html" target:"_blank">
+ <a class="navbar-item" href="work_endava.html" target="_blank">
```

## Reference
`work_repay_1.html` (working) was used as the baseline — it already has the correct `bulma@1.0.4` CDN URL and well-formed HTML.